### PR TITLE
Fix initialization of pseudo locales

### DIFF
--- a/HTMLFileType.js
+++ b/HTMLFileType.js
@@ -42,7 +42,7 @@ var HTMLFileType = function(project) {
     this.pseudos = {};
 
     // generate all the pseudo bundles we'll need
-    project.locales && project.locales.forEach(function(locale) {
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
         var pseudo = this.API.getPseudoBundle(locale, this, project);
         if (pseudo) {
             this.pseudos[locale] = pseudo;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # ilib-loctool-html
+
 Ilib loctool plugin to parse and localize static HTML files
+
+## License
+
+This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+file for more details.
+
+## Release Notes
+
+### v1.0.3
+
+- Fix a bug where the pseudo locales were not initialized properly.
+  This fix gets the right set of locales from the project settings to
+  see if any of them are pseudo locales.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-html",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "main": "./HTMLFileType.js",
     "description": "A loctool plugin that knows how to localize static html files",
     "license": "Apache-2.0",


### PR DESCRIPTION
- Fix a bug where the pseudo locales were not initialized properly. This fix gets the right set of locales from the project settings to see if any of them are pseudo locales.